### PR TITLE
Add projectz and compile step

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -136,7 +136,8 @@ var MsNpmGenerator = yeoman.generators.Base.extend({
         'testem',
         'mocha',
         'chai',
-        'xyz'
+        'xyz',
+        'projectz'
       ], { 'saveDev': true }, done)
     }
   },

--- a/app/index.js
+++ b/app/index.js
@@ -165,7 +165,9 @@ var MsNpmGenerator = yeoman.generators.Base.extend({
     }
 
     var done = this.async()
-    async.eachSeries(gitArgs, spawn, done)
+    this.spawnCommand('npm', ['run', 'readme']).on('close', () => {
+      async.eachSeries(gitArgs, spawn, done)
+    })
   }
 })
 

--- a/app/index.js
+++ b/app/index.js
@@ -95,6 +95,8 @@ var MsNpmGenerator = yeoman.generators.Base.extend({
         this.mkdir(this.moduleName)
         this.destinationRoot(this.moduleName)
       }
+      this.dest.mkdir('src')
+      this.dest.mkdir('dist')
     },
     metafiles: function () {
       this.template('_package.json', 'package.json', this.userValues)
@@ -120,7 +122,7 @@ var MsNpmGenerator = yeoman.generators.Base.extend({
   },
   writing: {
     projectfiles: function () {
-      this.src.copy('_index.js', 'index.js')
+      this.src.copy('_index.js', 'src/index.js')
     },
     testSpec: function () {
       this.dest.mkdir('test')
@@ -137,7 +139,10 @@ var MsNpmGenerator = yeoman.generators.Base.extend({
         'mocha',
         'chai',
         'xyz',
-        'projectz'
+        'projectz',
+        'babel-cli',
+        'babel-eslint',
+        'babel-preset-es2015'
       ], { 'saveDev': true }, done)
     }
   },

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -7,6 +7,5 @@
 Usage instructions go here
 
 <!-- HISTORY -->
-<!-- CONTRIBUTE -->
 <!-- BACKERS -->
 <!-- LICENSE -->

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -1,17 +1,12 @@
-# <%= _.slugify(moduleName) %>
-
-<%= moduleDescription %>
-
-[![NPM](https://nodei.co/npm/<%= _.slugify(moduleName) %>.png?downloads=true&stars=true)](https://nodei.co/npm/<%= _.slugify(moduleName) %>/)
-
-[![Media Suite](http://mediasuite.co.nz/ms-badge.png)](http://mediasuite.co.nz)
-
-[![Build Status](https://travis-ci.org/mediasuitenz/<%= _.slugify(moduleName) %>.svg)](https://travis-ci.org/<%= githubOrganizationOrUsername %>/<%= _.slugify(moduleName) %>)
-
-## Installation
-
-```
-npm install <%= _.slugify(moduleName) %> --save
-```
+<!-- TITLE -->
+<!-- BADGES -->
+<!-- DESCRIPTION -->
+<!-- INSTALL -->
 
 ## Usage
+Usage instructions go here
+
+<!-- HISTORY -->
+<!-- CONTRIBUTE -->
+<!-- BACKERS -->
+<!-- LICENSE -->

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -42,8 +42,29 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {},
+  "maintainers": [
+    "<%= authorName %> <%= authorEmail %>"
+  ],
+  "contributors": [],
   "badges": {
     "list": [
+      [
+        "badge",
+        {
+          "image": "https://mediasuite.co.nz/ms-badge.png",
+          "url": "https://mediasuite.co.nz",
+          "title": "The Media Suite",
+          "alt": "The Media Suite"
+        }
+      ],
+      "---",
+      [
+        "badge",
+        {
+          "image": "https://nodei.co/npm/<%= _.slugify(moduleName) %>.png?downloads=true&stars=true",
+          "url": "https://nodei.co/npm/<%= _.slugify(moduleName) %>"
+        }
+      ],
       "---",
       "travisci",
       "npmversion",
@@ -51,5 +72,8 @@
       "daviddm",
       "daviddmdev"
     ]
-  }
+  },
+  "sponsors": [
+    "The Media Suite (http://mediasuite.co.nz)"
+  ]
 }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,7 +3,7 @@
   "description": "<%= moduleDescription %>",
   "version": "0.0.0",
   "license": "MIT",
-  "main": "index.js",
+  "main": "./dist/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/<%= githubOrganizationOrUsername %>/<%= _.slugify(moduleName) %>.git"
@@ -26,7 +26,8 @@
     "test:ci": "mocha -R spec test",
     "test:dev": "testem .",
     "test": "npm run test:ci",
-    "prepublish": "npm test && npm prune",
+    "build": "babel src --presets babel-preset-es2015 --out-dir dist",
+    "prepublish": "npm test && npm prune && npm run build",
     "preversion:patch": "npm run test",
     "version:patch": "xyz -i patch",
     "preversion:minor": "npm run test",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -32,7 +32,8 @@
     "preversion:minor": "npm run test",
     "version:minor": "xyz -i minor",
     "preversion:major": "npm run test",
-    "version:major": "xyz -i major"
+    "version:major": "xyz -i major",
+    "readme": "projectz compile"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org"
@@ -40,5 +41,15 @@
   "keywords": <%= moduleKeywords %>,
   "dependencies": {},
   "devDependencies": {},
-  "peerDependencies": {}
+  "peerDependencies": {},
+  "badges": {
+    "list": [
+      "---",
+      "travisci",
+      "npmversion",
+      "npmdownloads",
+      "daviddm",
+      "daviddmdev"
+    ]
+  }
 }

--- a/app/templates/npmignore
+++ b/app/templates/npmignore
@@ -2,3 +2,4 @@ LICENSE
 .gitignore
 test/**/*
 test
+src


### PR DESCRIPTION
Fixes #8 
- Compile step allows writing the latest es6 natively via latest version of node and compiling back to es5 at publish time
- projectz makes managing readme documentation easier

@JonathanPrince 
